### PR TITLE
tod2map2: allow the use of mask in signal_srcsamp

### DIFF
--- a/tod2map2.py
+++ b/tod2map2.py
@@ -492,8 +492,10 @@ for out_ind in range(nouter):
 			if param["srcs"] == "none": srcs = None
 			else: srcs = pointsrcs.read(param["srcs"])
 			minamp = float(param["minamp"])
+			if "mask" in param: m = enmap.read_map(param["mask"]).astype(dtype)
+			else: m = None
 			signal = mapmaking.SignalSrcSamp(active_scans, dtype=dtype, comm=comm,
-					srcs=srcs, amplim=minamp)
+					srcs=srcs, amplim=minamp, mask=m)
 			signal_srcsamp = signal
 		else:
 			raise ValueError("Unrecognized signal type '%s'" % param["type"])


### PR DESCRIPTION
Allow the use of map-based mask when specifying signal srcsamp, for example
`-S srcsamp:mask=some_mask.fits`

This is to be used with: https://github.com/amaurea/enlib/pull/56